### PR TITLE
add shims with dune magic for 4.08 compat

### DIFF
--- a/qtest/Makefile
+++ b/qtest/Makefile
@@ -1,5 +1,5 @@
 
-QTEST_PREAMBLE=''
+QTEST_PREAMBLE='open Iter_shims_;; '
 DONTTEST=../src/iterLabels.ml ../src/mkflags.ml ../src/mkshims.ml ../src/bigarray/mkshims.ml
 QTESTABLE=$(filter-out $(DONTTEST), \
 	$(wildcard ../src/*.ml) \

--- a/qtest/Makefile
+++ b/qtest/Makefile
@@ -1,6 +1,6 @@
 
 QTEST_PREAMBLE=''
-DONTTEST=../src/iterLabels.ml ../src/mkflags.ml
+DONTTEST=../src/iterLabels.ml ../src/mkflags.ml ../src/mkshims.ml ../src/bigarray/mkshims.ml
 QTESTABLE=$(filter-out $(DONTTEST), \
 	$(wildcard ../src/*.ml) \
 	$(wildcard ../src/*.mli) \

--- a/src/Iter.ml
+++ b/src/Iter.ml
@@ -3,6 +3,8 @@
 
 (** {1 Simple and Efficient Iterators} *)
 
+open Iter_shims_
+
 (** Iter abstract iterator type *)
 type 'a t = ('a -> unit) -> unit
 

--- a/src/Iter.ml
+++ b/src/Iter.ml
@@ -398,7 +398,7 @@ let persistent_lazy (seq:'a t) =
       let seq' = MList.of_iter_with seq k in
       r := LazyCached (MList.to_iter seq')
 
-let sort ?(cmp=Pervasives.compare) seq =
+let sort ?(cmp=Stdlib.compare) seq =
   (* use an intermediate list, then sort the list *)
   let l = fold (fun l x -> x::l) [] seq in
   let l = List.fast_sort cmp l in
@@ -414,7 +414,7 @@ let sort ?(cmp=Pervasives.compare) seq =
 
 exception Exit_sorted
 
-let sorted ?(cmp=Pervasives.compare) seq =
+let sorted ?(cmp=Stdlib.compare) seq =
   let prev = ref None in
   try
     seq (fun x -> match !prev with
@@ -518,7 +518,7 @@ let uniq ?(eq=fun x y -> x = y) seq k =
     |> OUnit.assert_equal [1;2;3;4;3]
 *)
 
-let sort_uniq (type elt) ?(cmp=Pervasives.compare) seq =
+let sort_uniq (type elt) ?(cmp=Stdlib.compare) seq =
   let module S = Set.Make(struct
       type t = elt
       let compare = cmp
@@ -669,7 +669,7 @@ let group_join_by (type a) ?(eq=(=)) ?(hash=Hashtbl.hash) f c1 c2 =
   (group_join_by (fun s->s.[0]) \
     (of_str "abc") \
     (of_list ["abc"; "boom"; "attic"; "deleted"; "barbary"; "bop"]) \
-  |> map (fun (c,l)->c,List.sort Pervasives.compare l) \
+  |> map (fun (c,l)->c,List.sort Stdlib.compare l) \
   |> sort |> to_list)
 *)
 
@@ -1145,10 +1145,10 @@ let int_range_by ~step i j yield =
 
 (*$Q
   Q.(pair small_int small_int) (fun (i,j) -> \
-    let i = Pervasives.min i j and j = Pervasives.max i j in \
+    let i = Stdlib.min i j and j = Stdlib.max i j in \
     (i--j |> to_list) = (int_range_by ~step:1 i j |> to_list))
   Q.(pair small_int small_int) (fun (i,j) -> \
-    let i = Pervasives.min i j and j = Pervasives.max i j in \
+    let i = Stdlib.min i j and j = Stdlib.max i j in \
     (i--j |> to_rev_list) = (int_range_by ~step:~-1 j i |> to_list))
 *)
 
@@ -1360,7 +1360,7 @@ let sample k seq =
     let seq = of_list l in
     let a = sample n seq in
     (array_for_all (fun x -> exists ((=) x) seq) a)
-    && (Array.length a = Pervasives.min (length seq) n) )
+    && (Array.length a = Stdlib.min (length seq) n) )
 *)
 
 (** {2 Infix functions} *)

--- a/src/bigarray/IterBigarray.ml
+++ b/src/bigarray/IterBigarray.ml
@@ -3,7 +3,7 @@
 
 (** {1 Interface and Helpers for bigarrays} *)
 
-open! Bigarray
+open! IterBigarrayShims_
 
 let of_bigarray b yield =
   let len = Bigarray.Array1.dim b in
@@ -16,7 +16,7 @@ let mmap filename =
     let fd = Unix.openfile filename [Unix.O_RDONLY] 0 in
     let len = Unix.lseek fd 0 Unix.SEEK_END in
     let _ = Unix.lseek fd 0 Unix.SEEK_SET in
-    let b = Bigarray.Array1.map_file fd Bigarray.char Bigarray.c_layout false len in
+    let b = bigarray_map_file fd Bigarray.char Bigarray.c_layout false len in
     try
       of_bigarray b yield;
       Unix.close fd

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -2,7 +2,7 @@
 (library
   (name iter_bigarray)
   (public_name iter.bigarray)
-  (libraries iter bigarray)
+  (libraries iter bigarray unix)
   (modules IterBigarray IterBigarrayShims_)
   (wrapped false)
   (optional)

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -3,8 +3,18 @@
   (name iter_bigarray)
   (public_name iter.bigarray)
   (libraries iter bigarray)
+  (modules IterBigarray IterBigarrayShims_)
   (wrapped false)
   (optional)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
-  (ocamlopt_flags :standard (:include ../flambda.flags))
-  )
+  (ocamlopt_flags :standard (:include ../flambda.flags)))
+
+(executable
+  (name mkshims)
+  (modules mkshims)
+  (libraries dune.configurator))
+
+(rule
+  (targets IterBigarrayShims_.ml)
+  (deps mkshims.exe)
+  (action (with-stdout-to %{targets} (run ./mkshims.exe))))

--- a/src/bigarray/mkshims.ml
+++ b/src/bigarray/mkshims.ml
@@ -1,0 +1,17 @@
+
+module C = Configurator.V1
+
+let shims_pre_408 = "
+open! Bigarray
+let bigarray_map_file = Bigarray.Array1.map_file
+"
+let shims_post_408 = "
+let bigarray_map_file fd ty lay b len =
+  Unix.map_file fd ty lay b [| len |] |> Bigarray.array1_of_genarray
+"
+
+let () =
+  C.main ~name:"mkshims" (fun c ->
+    let version = C.ocaml_config_var_exn c "version" in
+    let major, minor = Scanf.sscanf version "%u.%u" (fun maj min -> maj, min) in
+    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_post_408))

--- a/src/bigarray/mkshims.ml
+++ b/src/bigarray/mkshims.ml
@@ -14,4 +14,4 @@ let () =
   C.main ~name:"mkshims" (fun c ->
     let version = C.ocaml_config_var_exn c "version" in
     let major, minor = Scanf.sscanf version "%u.%u" (fun maj min -> maj, min) in
-    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_post_408))
+    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_pre_408))

--- a/src/dune
+++ b/src/dune
@@ -2,17 +2,24 @@
   (targets flambda.flags)
   (deps mkflags.ml)
   (mode fallback)
-  (action
-    (run ocaml ./mkflags.ml))
-  )
+  (action (run ocaml ./mkflags.ml)))
+
+(executable
+  (name mkshims)
+  (modules mkshims)
+  (libraries dune.configurator))
+
+(rule
+  (targets Iter_shims_.ml)
+  (deps mkshims.exe)
+  (action (with-stdout-to %{targets} (run ./mkshims.exe))))
 
 (library
   (name iter)
   (public_name iter)
   (wrapped false)
-  (modules Iter IterLabels)
+  (modules Iter IterLabels Iter_shims_)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string -nolabels)
   (ocamlopt_flags :standard (:include flambda.flags))
-  (libraries bytes result)
-  )
+  (libraries bytes result))
 

--- a/src/mkshims.ml
+++ b/src/mkshims.ml
@@ -1,0 +1,11 @@
+
+module C = Configurator.V1
+
+let shims_pre_408 = "module Pervasives = Pervasives"
+let shims_post_408 = "module Pervasives = Stdlib"
+
+let () =
+  C.main ~name:"mkshims" (fun c ->
+    let version = C.ocaml_config_var_exn c "version" in
+    let major, minor = Scanf.sscanf version "%u.%u" (fun maj min -> maj, min) in
+    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_post_408))

--- a/src/mkshims.ml
+++ b/src/mkshims.ml
@@ -1,11 +1,11 @@
 
 module C = Configurator.V1
 
-let shims_pre_408 = "module Pervasives = Pervasives"
-let shims_post_408 = "module Pervasives = Stdlib"
+let shims_pre_408 = "module Stdlib = Pervasives"
+let shims_post_408 = "module Stdlib = Stdlib"
 
 let () =
   C.main ~name:"mkshims" (fun c ->
     let version = C.ocaml_config_var_exn c "version" in
     let major, minor = Scanf.sscanf version "%u.%u" (fun maj min -> maj, min) in
-    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_post_408))
+    print_endline (if (major, minor) >= (4,8) then shims_post_408 else shims_pre_408))


### PR DESCRIPTION
should solve deprecation warnings on 4.08, and the big bigarray shift.