### PR TITLE
Added `for_each` and `for_eachi`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ man/
 *.install
 .merlin
 .gh-pages
+_opam

--- a/src/Iter.ml
+++ b/src/Iter.ml
@@ -82,6 +82,10 @@ let iteri f seq =
        f !r x;
        incr r)
 
+let for_each seq f = iter f seq
+
+let for_eachi seq f = iteri f seq
+
 let fold f init seq =
   let r = ref init in
   seq (fun elt -> r := f !r elt);
@@ -1232,14 +1236,14 @@ end
 module Map = struct
   module type S = sig
     include Map.S
-    val to_iter : 'a t -> (key * 'a) iter 
+    val to_iter : 'a t -> (key * 'a) iter
     val of_iter : (key * 'a) iter -> 'a t
     val keys : 'a t -> key iter
     val values : 'a t -> 'a iter
     val to_list : 'a t -> (key * 'a) list
     val of_list : (key * 'a) list -> 'a t
 
-    val to_seq : 'a t -> (key * 'a) iter 
+    val to_seq : 'a t -> (key * 'a) iter
     (** @deprecated use {!to_iter} instead *)
 
     val of_seq : (key * 'a) iter -> 'a t
@@ -1338,7 +1342,7 @@ let sample k seq =
       if !i < k then
         a.(!i) <- x
       else
-        let j = Random.int (!i) in 
+        let j = Random.int (!i) in
         if j < k then a.(j) <- x
         else ()
     in

--- a/src/Iter.mli
+++ b/src/Iter.mli
@@ -39,7 +39,7 @@ type +'a t = ('a -> unit) -> unit
 type +'a iter = 'a t
 
 (** {b NOTE} Type [('a, 'b) t2 = ('a -> 'b -> unit) -> unit]
-    has been removed and subsumed by [('a * 'b) t] 
+    has been removed and subsumed by [('a * 'b) t]
     @since 1.0
 *)
 
@@ -118,7 +118,17 @@ val iter : ('a -> unit) -> 'a t -> unit
     Basically [iter f seq] is just [seq f]. *)
 
 val iteri : (int -> 'a -> unit) -> 'a t -> unit
-(** Iterate on elements and their index in the iterator *)
+    (** Iterate on elements and their index in the iterator *)
+
+val for_each : 'a t -> ('a -> unit) -> unit
+(** Consume the iterator, passing all its arguments to the function.
+    [for_each seq f] is the same as [iter f seq], i.e., [iter] with
+    arguments reversed. *)
+
+val for_eachi : 'a t -> (int -> 'a -> unit) -> unit
+(** Iterate on elements and their index in the iterator.
+    [for_eachi seq f] is the same as [iteri f seq], i.e., [iteri] with
+    arguments reversed. *)
 
 val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** Fold over elements of the iterator, consuming it *)
@@ -686,7 +696,7 @@ module Map : sig
     val to_list : 'a t -> (key * 'a) list
     val of_list : (key * 'a) list -> 'a t
 
-    val to_seq : 'a t -> (key * 'a) iter 
+    val to_seq : 'a t -> (key * 'a) iter
     (** @deprecated use {!to_iter} instead *)
 
     val of_seq : (key * 'a) iter -> 'a t
@@ -849,4 +859,3 @@ module IO : sig
     string -> Bytes.t t -> unit
   (** @since 0.5.4 *)
 end
-

--- a/src/Iter.mli
+++ b/src/Iter.mli
@@ -123,12 +123,14 @@ val iteri : (int -> 'a -> unit) -> 'a t -> unit
 val for_each : 'a t -> ('a -> unit) -> unit
 (** Consume the iterator, passing all its arguments to the function.
     [for_each seq f] is the same as [iter f seq], i.e., [iter] with
-    arguments reversed. *)
+    arguments reversed.
+    @since NEXT_RELEASE *)
 
 val for_eachi : 'a t -> (int -> 'a -> unit) -> unit
 (** Iterate on elements and their index in the iterator.
     [for_eachi seq f] is the same as [iteri f seq], i.e., [iteri] with
-    arguments reversed. *)
+    arguments reversed.
+    @since NEXT_RELEASE *)
 
 val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** Fold over elements of the iterator, consuming it *)

--- a/src/IterLabels.mli
+++ b/src/IterLabels.mli
@@ -91,12 +91,14 @@ val iteri : f:(int -> 'a -> unit) -> 'a t -> unit
 val for_each : seq:'a t -> ('a -> unit) -> unit
 (** Consume the iterator, passing all its arguments to the function.
     [for_each seq f] is the same as [iter f seq], i.e., [iter] with
-    arguments reversed. *)
+    arguments reversed.
+    @since NEXT_RELEASE *)
 
 val for_eachi : seq:'a t -> (int -> 'a -> unit) -> unit
 (** Iterate on elements and their index in the iterator.
     [for_eachi seq f] is the same as [iteri f seq], i.e., [iteri] with
-    arguments reversed. *)
+    arguments reversed.
+    @since NEXT_RELEASE *)
 
 val fold : f:('a -> 'b -> 'a) -> init:'a -> 'b t -> 'a
 (** Fold over elements of the iterator, consuming it *)

--- a/src/IterLabels.mli
+++ b/src/IterLabels.mli
@@ -15,7 +15,7 @@ type +'a t = ('a -> unit) -> unit
 type +'a iter = 'a t
 
 (** {b NOTE} Type [('a, 'b) t2 = ('a -> 'b -> unit) -> unit]
-    has been removed and subsumed by [('a * 'b) t] 
+    has been removed and subsumed by [('a * 'b) t]
     @since 1.0
  *)
 
@@ -87,6 +87,16 @@ val iter : f:('a -> unit) -> 'a t -> unit
 
 val iteri : f:(int -> 'a -> unit) -> 'a t -> unit
 (** Iterate on elements and their index in the iterator *)
+
+val for_each : seq:'a t -> ('a -> unit) -> unit
+(** Consume the iterator, passing all its arguments to the function.
+    [for_each seq f] is the same as [iter f seq], i.e., [iter] with
+    arguments reversed. *)
+
+val for_eachi : seq:'a t -> (int -> 'a -> unit) -> unit
+(** Iterate on elements and their index in the iterator.
+    [for_eachi seq f] is the same as [iteri f seq], i.e., [iteri] with
+    arguments reversed. *)
 
 val fold : f:('a -> 'b -> 'a) -> init:'a -> 'b t -> 'a
 (** Fold over elements of the iterator, consuming it *)
@@ -651,7 +661,7 @@ module Map : sig
     val to_list : 'a t -> (key * 'a) list
     val of_list : (key * 'a) list -> 'a t
 
-    val to_seq : 'a t -> (key * 'a) iter 
+    val to_seq : 'a t -> (key * 'a) iter
     (** @deprecated use {!to_iter} instead *)
 
     val of_seq : (key * 'a) iter -> 'a t


### PR DESCRIPTION
I often find myself writing these functions because they are easy to read in imperative-style code. Just two additions (with doc comments in the `.mli` files): `for_each` (resp. `for_eachi`) is just `iter` (resp. `iteri`) with arguments reversed.