### PR TITLE
fix: dune files

### DIFF
--- a/dune
+++ b/dune
@@ -1,8 +1,8 @@
 
 (alias
  (name runtest)
- (deps README.md)
+ (deps (:dep README.md))
  (action (progn
-          (run ocaml-mdx test %{deps})
-          (diff? %{deps} %{deps}.corrected))))
+          (run ocaml-mdx test %{dep})
+          (diff? %{dep} %{dep}.corrected))))
 


### PR DESCRIPTION
%{deps} is expanded into a list so we cannot use it in as a diff? param