### PR TITLE
Disable warning 70

### DIFF
--- a/benchs/dune
+++ b/benchs/dune
@@ -2,6 +2,6 @@
  (names bench_persistent_read bench_persistent benchs)
  (libraries iter benchmark)
  (optional)
- (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string -color always)
+ (flags :standard -w +a-4-42-44-48-50-58-32-60-70@8 -safe-string -color always)
  (ocamlopt_flags :standard -O3 -color always -unbox-closures
    -unbox-closures-factor 20))

--- a/examples/dune
+++ b/examples/dune
@@ -1,6 +1,6 @@
 (executable
  (name test_sexpr)
  (libraries iter)
- (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string -color always)
+ (flags :standard -w +a-4-42-44-48-50-58-32-60-70@8 -safe-string -color always)
  (ocamlopt_flags :standard -O3 -color always -unbox-closures
    -unbox-closures-factor 20))


### PR DESCRIPTION
When running `dune build` on a fresh clone of the repo (dune v 3.8.1) I was getting the following warnings:

```
$ dune build
File "benchs/benchs.ml", line 1:     
Warning 70 [missing-mli]: Cannot find interface file.
File "benchs/bench_persistent.ml", line 1:
Warning 70 [missing-mli]: Cannot find interface file.
File "benchs/bench_persistent_read.ml", line 1:
Warning 70 [missing-mli]: Cannot find interface file.
File "examples/test_sexpr.ml", line 1:
Warning 70 [missing-mli]: Cannot find interface file.
```

One fix: Disable warning 70 (missing-mli, Cannot find interface file) in the benches and examples dune file.

(Not sure if there is a reason you want the warning there or not.)