### PR TITLE
fix(map_by_2): Fixed bug in implementation and added some unit tests

### DIFF
--- a/src/Iter.ml
+++ b/src/Iter.ml
@@ -114,7 +114,7 @@ let map_by_2 f seq k =
   let f y =
     match !r with
     | None -> r := Some y
-    | Some x -> k (f x y)
+    | Some x -> r := None; k (f x y)
   in
   seq f;
   match !r with

--- a/src/Iter.ml
+++ b/src/Iter.ml
@@ -114,7 +114,9 @@ let map_by_2 f seq k =
   let f y =
     match !r with
     | None -> r := Some y
-    | Some x -> r := None; k (f x y)
+    | Some x ->
+      r := None;
+      k (f x y)
   in
   seq f;
   match !r with

--- a/tests/unit/t_iter.ml
+++ b/tests/unit/t_iter.ml
@@ -351,17 +351,20 @@ let () =
 (* map_by_2 tests *)
 let test = OUnit.assert_equal ~printer:Q.Print.(list int)
 let () = test [] (map_by_2 (fun a _ -> a) (of_list []) |> to_list)
+
 (* Test empty iterator *)
-let () = test [1] (map_by_2 (fun _ b -> b) (of_list [1]) |> to_list)
-let () = test [3] (map_by_2 (fun _ b -> b) (1--3) |> drop 1 |> to_list)
-let () = test [9] (map_by_2 (fun _ b -> b) (1--9) |> drop 4 |> to_list)
+let () = test [ 1 ] (map_by_2 (fun _ b -> b) (of_list [ 1 ]) |> to_list)
+let () = test [ 3 ] (map_by_2 (fun _ b -> b) (1 -- 3) |> drop 1 |> to_list)
+let () = test [ 9 ] (map_by_2 (fun _ b -> b) (1 -- 9) |> drop 4 |> to_list)
+
 (* Odd number of elements should leave the last element in the iterator.
    For an increasing integer range [1,2k] (fun _ b -> b) returns only
    even numbers so this is sufficient to test that this element is left
    in the iterator. *)
-let () = test [1] (map_by_2 (fun a _ -> a) (1--2) |> to_list)
-let () = test [2] (map_by_2 (fun _ b -> b) (1--2) |> to_list)
+let () = test [ 1 ] (map_by_2 (fun a _ -> a) (1 -- 2) |> to_list)
+let () = test [ 2 ] (map_by_2 (fun _ b -> b) (1 -- 2) |> to_list)
+
 (* Test two elements *)
-let () = test [1;3;5;7;9] (map_by_2 (fun a _ -> a) (1--10) |> to_list)
-let () = test [2;4;6;8;10] (map_by_2 (fun _ b -> b) (1--10) |> to_list)
+let () = test [ 1; 3; 5; 7; 9 ] (map_by_2 (fun a _ -> a) (1 -- 10) |> to_list)
+let () = test [ 2; 4; 6; 8; 10 ] (map_by_2 (fun _ b -> b) (1 -- 10) |> to_list)
 (* Test more than two elements *)

--- a/tests/unit/t_iter.ml
+++ b/tests/unit/t_iter.ml
@@ -347,3 +347,21 @@ let () =
 let () =
   let errcode = QCheck_base_runner.run_tests ~colors:false !qchecks in
   if errcode <> 0 then exit errcode
+
+(* map_by_2 tests *)
+let test = OUnit.assert_equal ~printer:Q.Print.(list int)
+let () = test [] (map_by_2 (fun a _ -> a) (of_list []) |> to_list)
+(* Test empty iterator *)
+let () = test [1] (map_by_2 (fun _ b -> b) (of_list [1]) |> to_list)
+let () = test [3] (map_by_2 (fun _ b -> b) (1--3) |> drop 1 |> to_list)
+let () = test [9] (map_by_2 (fun _ b -> b) (1--9) |> drop 4 |> to_list)
+(* Odd number of elements should leave the last element in the iterator.
+   For an increasing integer range [1,2k] (fun _ b -> b) returns only
+   even numbers so this is sufficient to test that this element is left
+   in the iterator. *)
+let () = test [1] (map_by_2 (fun a _ -> a) (1--2) |> to_list)
+let () = test [2] (map_by_2 (fun _ b -> b) (1--2) |> to_list)
+(* Test two elements *)
+let () = test [1;3;5;7;9] (map_by_2 (fun a _ -> a) (1--10) |> to_list)
+let () = test [2;4;6;8;10] (map_by_2 (fun _ b -> b) (1--10) |> to_list)
+(* Test more than two elements *)


### PR DESCRIPTION
It seems like this function was never properly tested since it didn't behave as expected. For example:

```ocaml
Iter.map_by_2
    (fun a b ->
      Printf.printf "%d - %d\n" a b;
      0)
    (Iter.of_list [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ])
  |> Iter.iter (fun _ -> ());
```
results in:
```
1 - 2
1 - 3
1 - 4
1 - 5
1 - 6
1 - 7
1 - 8
1 - 9
1 - 10
```
whereas one would expect:
```
1 - 2
3 - 4
5 - 6
7 - 8
9 - 10
```

This PR fixes the bug.