### PR TITLE
build: add `(package iter)` to ocaml-mdx rule

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (rule
  (alias runtest)
  (deps
+  (package iter)
   (:dep README.md))
  (action
   (progn


### PR DESCRIPTION
upcoming dune with fine-grained dependency filtering seems to surface a missing dependency in this rule:

```diff
File "README.md", line 1, characters 0-0:
(cd _build/default && /nix/store/ww555mznia5v7sz2w85lblg4amvhkhv1-diffutils-3.12/bin/diff -u --label README.md --label README.md.corrected README.md README.md.corrected)
--- README.md
+++ README.md.corrected
@@ -5,9 +5,11 @@
 
 ```ocaml
 # #require "iter";;
+No such package: iter
 # let p x = x mod 5 = 0 in
   Iter.(1 -- 5_000 |> filter p |> map (fun x -> x * x) |> fold (+) 0);;
-- : int = 8345837500
+Line 2, characters 3-7:
+Error: Unbound module Iter